### PR TITLE
feat(parser): label addresses zero-padded to 32 bytes (#29)

### DIFF
--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -24,7 +24,16 @@ export function abbreviatedAddresses(address: string): string[] {
   );
 }
 
-const ABBREVIATION_FUNCTIONS = [abbreviatedAddresses];
+// Spot addresses embedded into EVM 256 bit words.  This is typically
+// seen in event data.
+export function zeroPaddedAddress(address: string): string[] {
+  // Addresses are 20 bytes, so to pad to 32 bytes we need an extra
+  // 12 bytes of zero padding (24 nibbles).
+  const padded = '00'.repeat(12) + address.slice(2);
+  return [padded, '0x' + padded];
+}
+
+const ABBREVIATION_FUNCTIONS = [abbreviatedAddresses, zeroPaddedAddress];
 
 function addLabel(labelMap: LabelMap, i: number, line: string, address: string, label: string, comment?: string) {
   const addresses = [address];


### PR DESCRIPTION
Closes #29.