### PR TITLE
docs: minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
 <img src="public/icon-128.png" alt="logo"/>
 <h1>
@@ -62,7 +61,7 @@ After labelling the From and To addresses in rolod0x, it now looks like this:
 
 ![etherscan transaction with rolod0x](docs/images/etherscan-example-after.png)
 
-Not only that, but whenever these addresses appear on *any other website*,
+Not only that, but whenever these addresses appear on _any other website_,
 they will now be labelled in this human-readable way!
 
 [random-tx]: https://etherscan.io/tx/0x1e2a4312f7d48efd29ed5dbcca6cabae30214ea895ab54c9b789860cbe8d31dd
@@ -76,7 +75,7 @@ they will now be labelled in this human-readable way!
 - Works on any EVM-based blockchain (and could easily support other
   chains in the future).
 - Should work on Chrome, Chromium, Brave, or any other browser in the Chrome family.
-- *May* work on Firefox - not yet tested, but planned (see https://github.com/aspiers/rolod0x/issues/19).
+- _May_ work on Firefox - not yet tested, but planned (see https://github.com/aspiers/rolod0x/issues/19).
 - Named using [a triple pun](./docs/FAQ.md#name).
 
 ## Installation <a name="installation"></a>
@@ -95,11 +94,16 @@ cryptocurrency addresses:
 
 - Send **Bitcoin** to: `bc1quuspvrjepx63k5hpydwqkf6nmtt9eqm86y8w8a`
 
-- Send **ETH** / tokens on any Ethereum network to: `rolod0x.eth` (N.B. that's a zero before the `x`, not an uppercase `O` -- the address should resolve to `0x06357397d8078C19195f4555db7A407b1b1f5FB3`)
+- Send **ETH** / tokens on any Ethereum network to: `rolod0x.eth`
+  (N.B. that's a zero before the `x`, not an uppercase `O` -- the
+  address should resolve to `0x06357397d8078C19195f4555db7A407b1b1f5FB3`)
 
-Your contribution will go directly towards enhancing the project, covering development costs, and supporting ongoing maintenance.
+Your contribution will go directly towards enhancing the project,
+covering development costs, and supporting ongoing maintenance.
 
-We appreciate every donation, no matter the size.  It helps to ensure the project's sustainability and motivates us to continue delivering valuable updates and improvements.
+We appreciate every donation, no matter the size.  It helps to ensure
+the project's sustainability and motivates us to continue delivering
+valuable updates and improvements.
 
 Thank you for considering a donation to support our work!
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ any risk caused by using rolod0x.  Its design is inherently low risk since:
 - It only alters web pages by replacing addresses with labels supplied by
   the user.
 
-- It doesn't interact directly with the blockchain.  Indeed, once
-  installed, the extension doesn't rely on internet access *at all*;
+- It doesn't interact directly with the blockchain. Indeed, once
+  installed, the extension doesn't rely on internet access _at all_;
   it just inspects and alters web pages locally in the browser.
 
 - The data is stored locally within an isolated storage area in the

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -42,9 +42,9 @@ they have to pick one of two unsatisfactory options:
 Name services in web3 typically come in two forms:
 
 1. Public name services, most notably [ENS](https://ens.domains/).
-   ENS is an awesome service for labelling *public* addresses, but
-   it does not work as a *private* address book since all ENS
-   domains are public to the whole world.  Furthermore:
+   ENS is an awesome service for labelling _public_ addresses, but
+   it does not work as a _private_ address book since all ENS
+   domains are public to the whole world. Furthermore:
 
    - It costs gas every time you want to set up a domain.
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -40,8 +40,8 @@ Run:
 ### For Firefox: <a name="firefox"></a>
 
 1. Run:
-    - Dev: `pnpm dev:firefox` or `npm run dev:firefox`
-    - Prod: `pnpm build:firefox` or `npm run build:firefox`
+   - Dev: `pnpm dev:firefox` or `npm run dev:firefox`
+   - Prod: `pnpm build:firefox` or `npm run build:firefox`
 
 ### Installation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,6 @@
 - [Upgrading a Chrome installation](#chrome-upgrade)
 - [Installation in Firefox](#firefox)
 
-
 ## Downloads <a name="downloads"></a>
 
 In the (hopefully near) future, rolod0x will be available from the Chrome
@@ -70,8 +69,7 @@ again on next launch.**
 
 ## Installation from source <a name="source"></a>
 
-
-the [developer guide][].
+See the [developer guide][].
 
 Any [pull request][using PRs] providing an enhancement or bugfix is
 extremely welcome!


### PR DESCRIPTION
Some of these were discovered by stopping prettier ignoring markdown files and running `prettier --fix`, but that config wasn't kept because super annoyingly it trims double spaces at the end of sentences, for reasons covered in https://github.com/prettier/prettier/issues/9810.