### PR TITLE
fix(mapper): treat zeroPaddedAddress() as a transformation

### DIFF
--- a/src/shared/abbreviators.test.ts
+++ b/src/shared/abbreviators.test.ts
@@ -1,4 +1,4 @@
-import { abbreviatedAddresses, zeroPaddedAddress } from './abbreviators';
+import { abbreviatedAddresses } from './abbreviators';
 
 describe('abbreviatedAddresses()', () => {
   it('outputs an array of abbreviated addresses', () => {
@@ -7,15 +7,6 @@ describe('abbreviatedAddresses()', () => {
       '0x6B17...1d0F',
       '0x6B1754...95271d0F',
       '0x6B1...71d0F',
-    ]);
-  });
-});
-
-describe('zeroPaddedAddress', () => {
-  it('outputs an array of two zero-padded addresses', () => {
-    expect(zeroPaddedAddress('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toEqual([
-      '0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',
-      '0x0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',
     ]);
   });
 });

--- a/src/shared/abbreviators.ts
+++ b/src/shared/abbreviators.ts
@@ -22,13 +22,4 @@ export function abbreviatedAddresses(address: string): string[] {
   );
 }
 
-// Spot addresses embedded into EVM 256 bit words.  This is typically
-// seen in event data.
-export function zeroPaddedAddress(address: string): string[] {
-  // Addresses are 20 bytes, so to pad to 32 bytes we need an extra
-  // 12 bytes of zero padding (24 nibbles).
-  const padded = '00'.repeat(12) + address.slice(2);
-  return [padded, '0x' + padded];
-}
-
-export const ABBREVIATION_FUNCTIONS = [abbreviatedAddresses, zeroPaddedAddress];
+export const ABBREVIATION_FUNCTIONS = [abbreviatedAddresses];

--- a/src/shared/mapper.ts
+++ b/src/shared/mapper.ts
@@ -1,4 +1,5 @@
 import { ABBREVIATION_FUNCTIONS } from './abbreviators';
+import { TRANSFORMER_FUNCTIONS } from './transformers';
 import { Formatter } from './formatter';
 import { Address, AddressLabelComment, LabelComment, LabelMap, ParsedEntries } from './types';
 
@@ -28,6 +29,13 @@ export class Mapper {
     // data.address is guaranteed to be ERC-55 checksummed
     this.labelMap.set(address, value);
     this.labelMap.set(address.toLowerCase(), value);
+
+    for (const func of TRANSFORMER_FUNCTIONS) {
+      for (const transformed of func(address)) {
+        this.labelMap.set(transformed, value);
+        this.labelMap.set(transformed.toLowerCase(), value);
+      }
+    }
 
     // The abbreviated form has a small risk of collisions,
     // so technically this is "just" a well-educated guess,

--- a/src/shared/transformers.test.ts
+++ b/src/shared/transformers.test.ts
@@ -1,0 +1,12 @@
+import { zeroPaddedAddress } from './transformers';
+
+describe('zeroPaddedAddress', () => {
+  it('outputs an array of four zero-padded addresses', () => {
+    expect(zeroPaddedAddress('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toEqual([
+      '0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',
+      '0x0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',
+      '0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f',
+      '0x0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f',
+    ]);
+  });
+});

--- a/src/shared/transformers.ts
+++ b/src/shared/transformers.ts
@@ -1,0 +1,11 @@
+// Spot addresses embedded into EVM 256 bit words.  This is typically
+// seen in event data.
+export function zeroPaddedAddress(address: string): string[] {
+  // Addresses are 20 bytes, so to pad to 32 bytes we need an extra
+  // 12 bytes of zero padding (24 nibbles).
+  const padded = '00'.repeat(12) + address.slice(2);
+  const addrs = [padded, '0x' + padded];
+  return [...addrs, ...addrs.map(a => a.toLowerCase())];
+}
+
+export const TRANSFORMER_FUNCTIONS = [zeroPaddedAddress];


### PR DESCRIPTION
`zeroPaddedAddress()` was being treated as an abbreviator, but there is no guesswork involved as it left-pads a full address.  So split this out into a new transformers.ts file, and substitute zero-padded addresses with the normal format not the guess format.

Also substitute lowercase zero-padded addresses, as seen on the likes of polygonscan in the Events tab of smart contract pages.