### PR TITLE
feat(import): add  `pnpm tokenlist:import` script

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -3,6 +3,7 @@
 - [Usage in Chrome and similar](#chrome)
 - [Usage in other browsers](#other)
 - [Usage on the command line](#cli)
+- [Importing token lists on the command line](#import-tokenlist)
 
 ## Usage in Chrome and similar <a name="chrome"></a>
 
@@ -149,3 +150,18 @@ pipe STDOUT and STDERR through rolod0x.
 If you specify the `-d` or `--duplicates` option, then instead of
 filtering `STDIN`, it will list all addresses in the given address
 book file which have duplicate labels.
+
+## Importing token lists on the command line <a name="import-tokenlist"></a>
+
+If you want to augment your private address book with some well-known
+public addresses, take a look at https://tokenlists.org/ has a nice
+list of public token lists.
+
+You can of course copy any of these into your address book manually,
+but you can also convert a whole list into rolod0x, by downloading the
+source JSON file, and then running something like the following:
+
+    pnpm --silent tokenlist:import tokens.json > tokens.txt
+
+The contents of the resulting `tokens.txt` file can then be imported
+into rolod0x simply by pasting them into the address book.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint:eslint:fix": "pnpm eslint --fix",
     "lint:prettier": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
+    "tokenlist:import": "pnpm exec tsx ./src/import-tokenlist.ts",
     "prepare": "husky install",
     "rolod0x": "pnpm exec tsx ./src/cli.ts",
     "website:prepare": "./scripts/website-prepare.sh"
@@ -61,6 +62,7 @@
     "ethers": "^6.11.1",
     "lodash": "^4.17.21",
     "murmurhash": "^2.0.1",
+    "node-fetch": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   murmurhash:
     specifier: ^2.0.1
     version: 2.0.1
+  node-fetch:
+    specifier: ^3.3.2
+    version: 3.3.2
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -621,20 +624,6 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.0)(@codemirror/state@6.4.1)(@codemirror/view@6.25.1)(@lezer/common@1.2.1):
-    resolution: {integrity: sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==}
-    peerDependencies:
-      '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
-      '@lezer/common': ^1.0.0
-    dependencies:
-      '@codemirror/language': 6.10.0
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.25.1
-      '@lezer/common': 1.2.1
-    dev: false
-
   /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.0)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1):
     resolution: {integrity: sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==}
     peerDependencies:
@@ -693,7 +682,7 @@ packages:
     resolution: {integrity: sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==}
     dependencies:
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.25.1
+      '@codemirror/view': 6.26.3
       crelt: 1.0.6
     dev: false
 
@@ -705,16 +694,8 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.0
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.25.1
+      '@codemirror/view': 6.26.3
       '@lezer/highlight': 1.2.0
-    dev: false
-
-  /@codemirror/view@6.25.1:
-    resolution: {integrity: sha512-2LXLxsQnHDdfGzDvjzAwZh2ZviNJm7im6tGpa0IONIDnFd8RZ80D2SNi8PDi6YjKcMoMRK20v6OmKIdsrwsyoQ==}
-    dependencies:
-      '@codemirror/state': 6.4.1
-      style-mod: 4.1.0
-      w3c-keyname: 2.2.8
     dev: false
 
   /@codemirror/view@6.26.3:
@@ -3912,13 +3893,13 @@ packages:
   /codemirror@6.0.1(@lezer/common@1.2.1):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.0)(@codemirror/state@6.4.1)(@codemirror/view@6.25.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.0)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.3.3
       '@codemirror/language': 6.10.0
       '@codemirror/lint': 6.4.2
       '@codemirror/search': 6.5.5
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.25.1
+      '@codemirror/view': 6.26.3
     transitivePeerDependencies:
       - '@lezer/common'
     dev: false
@@ -4320,7 +4301,6 @@ packages:
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-    dev: true
 
   /data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
@@ -5596,7 +5576,6 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.2
-    dev: true
 
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -5716,7 +5695,6 @@ packages:
     engines: {node: '>=12.20.0'}
     dependencies:
       fetch-blob: 3.2.0
-    dev: true
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -8023,7 +8001,6 @@ packages:
   /node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    dev: true
 
   /node-fetch@3.3.1:
     resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}
@@ -8033,6 +8010,15 @@ packages:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
     dev: true
+
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+    dev: false
 
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -10552,7 +10538,6 @@ packages:
   /web-streams-polyfill@3.3.2:
     resolution: {integrity: sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==}
     engines: {node: '>= 8'}
-    dev: true
 
   /webext-additional-permissions@2.4.0:
     resolution: {integrity: sha512-u4g2taAPJZiwVftQek6pd7LfV6zuhMRRpsy/6SyAn2KBylbXKpY8KVVX7tOpJuuS6DMTLL5Fr49+p5e3SIX9YA==}

--- a/src/import-tokenlist.ts
+++ b/src/import-tokenlist.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env tsx
+
+import * as fs from 'fs';
+
+import _ from 'lodash';
+import fetch from 'node-fetch';
+
+const CHAINS_URL = 'https://chainid.network/chains.json';
+
+type Chain = {
+  name: string;
+  chainId: number;
+};
+
+const response = await fetch(CHAINS_URL);
+const chainList = (await response.json()) as Chain[];
+const chainsById = _.keyBy(chainList, 'chainId');
+// const chains = JSON.parse(fs.readFileSync('./src/assets/chainIds.json', 'utf8'));
+
+const json = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+
+for (const tokenData of json.tokens) {
+  const { address, name, chainId } = tokenData;
+  const chainName = chainsById[chainId].name || `chain id ${chainId}`;
+  const chainSuffix = chainName ? ` (${chainName})` : '';
+  console.log(address, name + chainSuffix);
+}


### PR DESCRIPTION
If you want to augment your private address book with some well-known public addresses, take a look at https://tokenlists.org/ has a nice list of public token lists.

You can of course copy any of these into your address book manually, but you can also convert a whole list into rolod0x, by downloading the source JSON file, and then running something like the following:

    pnpm --silent tokenlist:import tokens.json > tokens.txt

The contents of the resulting `tokens.txt` file can then be imported into rolod0x simply by pasting them into the address book.