### PR TITLE
ci: update-assignees CI workflow

### DIFF
--- a/.github/workflows/update-assignees.yml
+++ b/.github/workflows/update-assignees.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - reopened
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   update-assignees:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Presumably this got broken by the move to the rolod0x org?