### PR TITLE
fix(manifest): automatically enable on app.koinly.io

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -32,7 +32,7 @@ const defaultSites = [
 
   // Portfolio trackers
   'https://coinshift.xyz/*',
-  'https://koinly.io/*',
+  'https://*.koinly.io/*',
   'https://cointracker.io/*',
   'https://coinstats.app/*',
   'https://accointing.com/*',


### PR DESCRIPTION
The entry for koinly.io in the manifest was missing a wildcard, so it wasn't automatically activating on koinly.io.