### PR TITLE
hide tour close button

### DIFF
--- a/src/pages/options/AddressesSettings/index.tsx
+++ b/src/pages/options/AddressesSettings/index.tsx
@@ -289,6 +289,7 @@ export default function AddressesSettings() {
         steps={tourSteps}
         run={runTour}
         continuous
+        hideCloseButton
         showSkipButton
         showProgress
         disableScrolling={false}


### PR DESCRIPTION
It was doing the same as the "Next" button, which is confusing, and
anyway there's already a "Skip" button.