### PR TITLE
fix the console.l{debug,log,error} extension imports

### DIFF
--- a/src/shared/hooks/useAddressBook.ts
+++ b/src/shared/hooks/useAddressBook.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import * as murmurhash from 'murmurhash';
 
+import '@src/shared/console';
 import { Parser, ParseError } from '@src/shared/parser';
 import { optionsStorage, Rolod0xAddressBookSection } from '@src/shared/options-storage';
 

--- a/src/shared/mapper.ts
+++ b/src/shared/mapper.ts
@@ -2,6 +2,7 @@ import { ABBREVIATION_FUNCTIONS } from './abbreviators';
 import { TRANSFORMER_FUNCTIONS } from './transformers';
 import { Formatter } from './formatter';
 import { Address, AddressLabelComment, LabelComment, LabelMap, ParsedEntries } from './types';
+import './console';
 
 export class Mapper {
   exactFormatter: Formatter;

--- a/src/shared/options-storage.ts
+++ b/src/shared/options-storage.ts
@@ -2,6 +2,8 @@ import { v4 as uuidv4 } from 'uuid';
 import OptionsSync from 'webext-options-sync';
 import { z } from 'zod';
 
+import '@src/shared/console';
+
 export interface Rolod0xOptionsV1 {
   themeName: 'light' | 'dark';
   labels: string;


### PR DESCRIPTION
Fixes a regression from #468.

Apparently they still weren't working despite multiple efforts, so
give up on trying to provide them globally, and instead always
manually import in each file which uses them.