### PR TITLE
Add Solana support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,20 @@ possible.
 - Follow the established code style
 - Follow all best practices below
 
+## GitHub Guidelines
+
+- When you cannot access a GitHub issue or review via a web search, try using the `gh` command.
+- Read an issue and all its comments with `gh issue view <id> --comments`. When you
+  read an issue, always read all the comments.
+- List reviews on a PR:
+  `gh api repos/:owner/:repo/pulls/<pr_number>/reviews`
+- Fetch all review comments for a specific review:
+  `gh api repos/:owner/:repo/pulls/<pr_number>/reviews/<review_id>/comments`
+- For quick inspection, you can pipe JSON through `jq`, for example:
+  - `gh api repos/:owner/:repo/pulls/105/reviews | jq '.[].id, .[].user.login'`
+  - `gh api repos/:owner/:repo/pulls/105/reviews/<review_id>/comments | jq '.[].body'`
+
+
 ## Best practices
 
 ### General best practices

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ they will now be labelled in this human-readable way!
 - Instantly look up an address via a keyboard shortcut.
 - Quick actions to copy addresses, search, or view on block explorers.
 - Works on any website.
-- Works on any EVM-based blockchain (and could easily support other
+- Works on any EVM-based blockchain and Solana (and could easily support other
   chains in the future).
 - Should work on Chrome, Chromium, Brave, or any other browser in the Chrome family.
 - Should work on Firefox (see <https://github.com/rolod0x/rolod0x/issues/19>).

--- a/manifest.js
+++ b/manifest.js
@@ -21,6 +21,7 @@ const defaultSites = [
   'https://explorer.bitquery.io/*',
   'https://*.oklink.com/*',
   'https://*.metasleuth.io/*',
+  'https://solscan.io/*',
 
   // Multisig management services
   'https://app.safe.global/*',

--- a/manifest.js
+++ b/manifest.js
@@ -22,10 +22,15 @@ const defaultSites = [
   'https://*.oklink.com/*',
   'https://*.metasleuth.io/*',
   'https://solscan.io/*',
+  'https://solana.fm/*',
+  'https://explorer.solana.com/*',
+  'https://orbmarkets.io/*',
 
   // Multisig management services
   'https://app.safe.global/*',
   'https://safe.celo.org/*',
+  'https://app.squads.so/*',
+  'https://safe.snowflake.so/*',
 
   // Developer services
   'https://bugs.immunefi.com/*',

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@mui/icons-material": "^5.16.11",
     "@mui/material": "^5.16.11",
     "@mui/system": "^5.16.8",
+    "@solana/addresses": "^2.0.0",
     "@types/lodash": "^4.17.13",
     "@types/webextension-polyfill": "^0.10.7",
     "@uiw/codemirror-themes": "^4.23.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@mui/system':
         specifier: ^5.16.8
         version: 5.16.8(@emotion/react@11.14.0(@types/react@18.3.16)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.16)(react@18.3.1))(@types/react@18.3.16)(react@18.3.1))(@types/react@18.3.16)(react@18.3.1)
+      '@solana/addresses':
+        specifier: ^2.0.0
+        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
@@ -73,7 +76,7 @@ importers:
         version: 1.5.3(babel-plugin-macros@3.1.0)
       ethers:
         specifier: ^6.13.4
-        version: 6.13.4
+        version: 6.13.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -179,7 +182,7 @@ importers:
         version: 4.3.4(vite@5.4.11(@types/node@22.10.2)(sass@1.83.0))
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@types/node@22.10.2)(jsdom@25.0.1)(sass@1.83.0))
+        version: 2.1.8(vitest@2.1.8(@types/node@22.10.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(sass@1.83.0))
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
@@ -221,7 +224,7 @@ importers:
         version: 9.1.7
       jsdom:
         specifier: ^25.0.1
-        version: 25.0.1
+        version: 25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       lint-staged:
         specifier: ^15.2.11
         version: 15.2.11
@@ -233,7 +236,7 @@ importers:
         version: 3.4.2
       react-devtools:
         specifier: ^5.3.2
-        version: 5.3.2
+        version: 5.3.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       rollup:
         specifier: ^4.28.1
         version: 4.28.1
@@ -254,16 +257,16 @@ importers:
         version: 0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.2)(sass@1.83.0))
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@22.10.2)(jsdom@25.0.1)(sass@1.83.0)
+        version: 2.1.8(@types/node@22.10.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(sass@1.83.0)
       vitest-chrome:
         specifier: github:aspiers/vitest-chrome#fix-esm
         version: https://codeload.github.com/aspiers/vitest-chrome/tar.gz/b98e2677af9ca91f4b74afbf10b7ac00ee369148
       web-ext:
         specifier: ^8.3.0
-        version: 8.3.0(node-fetch@3.3.2)
+        version: 8.3.0(bufferutil@4.0.9)(node-fetch@3.3.2)(utf-8-validate@5.0.10)
       ws:
         specifier: ^8.18.0
-        version: 8.18.0
+        version: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
 packages:
 
@@ -1318,6 +1321,44 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@solana/addresses@2.0.0':
+    resolution: {integrity: sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/assertions@2.0.0':
+    resolution: {integrity: sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-core@2.0.0':
+    resolution: {integrity: sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0':
+    resolution: {integrity: sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-strings@2.0.0':
+    resolution: {integrity: sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
+  '@solana/errors@2.0.0':
+    resolution: {integrity: sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1876,6 +1917,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.0.9:
+    resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
+    engines: {node: '>=6.14.2'}
 
   bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
@@ -2711,6 +2756,9 @@ packages:
 
   fast-uri@3.0.3:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -3739,6 +3787,10 @@ packages:
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
@@ -4894,6 +4946,10 @@ packages:
   url-parse-lax@1.0.0:
     resolution: {integrity: sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==}
     engines: {node: '>=0.10.0'}
+
+  utf-8-validate@5.0.10:
+    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+    engines: {node: '>=6.14.2'}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6282,6 +6338,46 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@solana/addresses@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
+    dependencies:
+      '@solana/assertions': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+      '@solana/errors': 2.0.0(typescript@5.7.2)
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@2.0.0(typescript@5.7.2)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.7.2)
+      typescript: 5.7.2
+
+  '@solana/codecs-core@2.0.0(typescript@5.7.2)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.7.2)
+      typescript: 5.7.2
+
+  '@solana/codecs-numbers@2.0.0(typescript@5.7.2)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
+      '@solana/errors': 2.0.0(typescript@5.7.2)
+      typescript: 5.7.2
+
+  '@solana/codecs-strings@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.7.2)
+      '@solana/errors': 2.0.0(typescript@5.7.2)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.7.2
+
+  '@solana/errors@2.0.0(typescript@5.7.2)':
+    dependencies:
+      chalk: 5.3.0
+      commander: 12.1.0
+      typescript: 5.7.2
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -6566,7 +6662,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@types/node@22.10.2)(jsdom@25.0.1)(sass@1.83.0))':
+  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@types/node@22.10.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(sass@1.83.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -6580,7 +6676,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@22.10.2)(jsdom@25.0.1)(sass@1.83.0)
+      vitest: 2.1.8(@types/node@22.10.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(sass@1.83.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6986,6 +7082,11 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bufferutil@4.0.9:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
 
   bundle-name@3.0.0:
     dependencies:
@@ -7925,7 +8026,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  ethers@6.13.4:
+  ethers@6.13.4(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -7933,7 +8034,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -8035,6 +8136,8 @@ snapshots:
   fast-redact@3.5.0: {}
 
   fast-uri@3.0.3: {}
+
+  fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.17.1:
     dependencies:
@@ -8676,7 +8779,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@25.0.1:
+  jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       cssstyle: 4.1.0
       data-urls: 5.0.0
@@ -8697,7 +8800,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.1.0
-      ws: 8.18.0
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -9030,6 +9133,9 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-notifier@10.0.1:
     dependencies:
@@ -9429,21 +9535,21 @@ snapshots:
       csstype: 3.1.3
       lodash-es: 4.17.21
 
-  react-devtools-core@5.3.2:
+  react-devtools-core@5.3.2(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       shell-quote: 1.8.1
-      ws: 7.5.9
+      ws: 7.5.9(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  react-devtools@5.3.2:
+  react-devtools@5.3.2(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       cross-spawn: 5.1.0
       electron: 23.3.13
       internal-ip: 6.2.0
       minimist: 1.2.8
-      react-devtools-core: 5.3.2
+      react-devtools-core: 5.3.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       update-notifier: 2.5.0
     transitivePeerDependencies:
       - bufferutil
@@ -10278,6 +10384,11 @@ snapshots:
     dependencies:
       prepend-http: 1.0.4
 
+  utf-8-validate@5.0.10:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   util-deprecate@1.0.2: {}
 
   uuid@11.0.3: {}
@@ -10343,7 +10454,7 @@ snapshots:
     dependencies:
       '@types/chrome': 0.0.114
 
-  vitest@2.1.8(@types/node@22.10.2)(jsdom@25.0.1)(sass@1.83.0):
+  vitest@2.1.8(@types/node@22.10.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(sass@1.83.0):
     dependencies:
       '@vitest/expect': 2.1.8
       '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(sass@1.83.0))
@@ -10367,7 +10478,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.2
-      jsdom: 25.0.1
+      jsdom: 25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -10417,7 +10528,7 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-ext@8.3.0(node-fetch@3.3.2):
+  web-ext@8.3.0(bufferutil@4.0.9)(node-fetch@3.3.2)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/runtime': 7.25.6
       '@devicefarmer/adbkit': 3.2.6
@@ -10444,7 +10555,7 @@ snapshots:
       tmp: 0.2.3
       update-notifier: 7.3.1
       watchpack: 2.4.2
-      ws: 8.18.0
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       yargs: 17.7.2
       zip-dir: 2.0.0
     transitivePeerDependencies:
@@ -10632,11 +10743,20 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@7.5.9: {}
+  ws@7.5.9(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
 
-  ws@8.17.1: {}
+  ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
 
-  ws@8.18.0: {}
+  ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
 
   xdg-basedir@3.0.0: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import * as readline from 'readline';
 import { Command } from '@commander-js/extra-typings';
 
 import { Formatter } from './shared/formatter';
-import { RE_ADDRESS_OR_BYTES32 } from './shared/regexps';
+import { RE_ADDRESSES_OR_BYTES32 } from './shared/regexps';
 import { Mapper } from './shared/mapper';
 import { Parser } from './shared/parser';
 
@@ -23,8 +23,8 @@ export function run(): void {
     .name('rolod0x')
     .description('CLI for mapping blockchain addresses to labels')
     .version('0.1.0')
-    .option('-f, --format <FORMAT>', 'Label format for exact address matches', '%n (0x%4l…%4r)')
-    .option('-p, --partial <FORMAT>', 'Label format for partial address matches', '[0x%4l…%n?…%4r]')
+    .option('-f, --format <FORMAT>', 'Label format for exact address matches', '%n (%4l…%4r)')
+    .option('-p, --partial <FORMAT>', 'Label format for partial address matches', '[%4l…%n?…%4r]')
     .option('-d, --duplicates', 'Show duplicates')
     .argument('<ADDRESS-FILE>', 'path to address book file')
     .action((addressesFile: string, options: CLIOptions) => {
@@ -79,7 +79,7 @@ function getParser(addressesFile: string): Parser {
 function replaceStdin(addressesFile: string, options: CLIOptions): void {
   const mapper = getMapper(addressesFile, options);
   const rl = readline.createInterface({ input: process.stdin });
-  const regexp = new RegExp(RE_ADDRESS_OR_BYTES32.source, 'gi');
+  const regexp = new RegExp(RE_ADDRESSES_OR_BYTES32.source, 'g');
   rl.on('line', (line: string) => {
     const mapped = line.replace(regexp, (match: string) => replacer(mapper, match));
     console.log(mapped);

--- a/src/pages/content/contextMenu.ts
+++ b/src/pages/content/contextMenu.ts
@@ -1,7 +1,7 @@
 import { getCanonicalAddress } from '@src/shared/address';
 import { getMapper, isNewAddress } from '@src/shared/address-book';
 // import { getBadgeText } from '@src/shared/badge';
-import { RE_ADDRESS } from '@src/shared/regexps';
+import { RE_ADDRESS_FORMATS } from '@src/shared/regexps';
 
 import { replaceInNodeAndCount } from './replacer';
 
@@ -15,7 +15,7 @@ async function addLabelForClickedElement(): Promise<void> {
 
   let url = IFRAME_URL;
 
-  const match = clickedEl.outerHTML?.match(RE_ADDRESS);
+  const match = clickedEl.outerHTML?.match(RE_ADDRESS_FORMATS);
   if (match) {
     const address = match[0];
     const canonical = getCanonicalAddress(address);
@@ -24,7 +24,7 @@ async function addLabelForClickedElement(): Promise<void> {
       return;
     }
 
-    const isNew = await isNewAddress(address);
+    const isNew = await isNewAddress(canonical);
     if (isNew) {
       console.debug('rolod0x: Found address in element:', canonical);
       url += `?address=${canonical}`;

--- a/src/pages/content/replacer.test.ts
+++ b/src/pages/content/replacer.test.ts
@@ -56,6 +56,7 @@ describe('replacer', () => {
   const parser = new Parser(dedent`
     0xe3D82337F79306712477b642EF59B75dD62eF109 my label       // ERC-55
     0x1803982898d6a8e832177fca8fd763b9060c3b5d another label  // all lowercase
+    DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK Solana label // Solana
   `);
   const exact = new Formatter('%n | %4r');
   const guess = new Formatter('?%n? %4r');
@@ -201,6 +202,26 @@ describe('replacer', () => {
 
   it("doesn't replace abbreviations linked to invalid addresses", () => {
     expectNoLinkReplacement('0xe3D800000000000000000000000000000000F109', '0xe3d8...f109');
+  });
+
+  it('replaces a full Solana address', () => {
+    expectSpanReplacement('DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK', 'Solana label | NSKK');
+  });
+
+  it('replaces Solana abbreviation with a guess', () => {
+    expectSpanReplacement('DYw8jCTfwH...KUmG5CNSKK', '?Solana label? NSKK');
+  });
+
+  it('replaces Solana abbreviation linked to known Solana address with exact match', () => {
+    expectLinkReplacement(
+      'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK',
+      'DYw8jCTfwH...KUmG5CNSKK',
+      'Solana label | NSKK',
+    );
+  });
+
+  it("doesn't replace an unknown Solana address", () => {
+    expectNoSpanReplacement('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
   });
 
   const HTML_ORIG = dedent`

--- a/src/pages/content/replacer.test.ts
+++ b/src/pages/content/replacer.test.ts
@@ -220,6 +220,14 @@ describe('replacer', () => {
     );
   });
 
+  it("falls back to the text node for Solana when the linked address case doesn't match", () => {
+    expectLinkReplacement(
+      'dyw8jctfwhnrjhhmfcbxvvdtqwmevfbx6zkumg5cnskk',
+      'DYw8jCTfwH...KUmG5CNSKK',
+      '?Solana label? NSKK',
+    );
+  });
+
   it("doesn't replace an unknown Solana address", () => {
     expectNoSpanReplacement('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
   });

--- a/src/pages/content/replacer.ts
+++ b/src/pages/content/replacer.ts
@@ -1,7 +1,7 @@
 import * as browser from 'webextension-polyfill';
 
 import { isAbbreviation } from '@src/shared/abbreviators';
-import { RE_ADDRESS } from '@src/shared/regexps';
+import { RE_ADDRESS_FORMATS } from '@src/shared/regexps';
 import { LabelComment, LabelMap } from '@src/shared/types';
 
 type ReplacementData = [textToLookup: string, before: string, data: LabelComment, after: string];
@@ -19,7 +19,7 @@ function getAddressFromAttribute(
   const value = element.getAttribute(attributeName);
   if (!value) return null;
 
-  const m = value.match(RE_ADDRESS);
+  const m = value.match(RE_ADDRESS_FORMATS);
   return m ? m[0] : null;
 }
 

--- a/src/pages/content/replacer.ts
+++ b/src/pages/content/replacer.ts
@@ -1,5 +1,6 @@
 import * as browser from 'webextension-polyfill';
 
+import { getAddressTypeOrThrow, isAddressTypeCaseSensitive } from '@src/shared/address-type';
 import { isAbbreviation } from '@src/shared/abbreviators';
 import { RE_ADDRESS_FORMATS } from '@src/shared/regexps';
 import { LabelComment, LabelMap } from '@src/shared/types';
@@ -134,6 +135,15 @@ export function getTextNodeReplacementData(node: Node, labelMap: LabelMap): Repl
   return [textToLookup, before, data, after];
 }
 
+function textMatchesLinkedAddress(textToLookup: string, hrefAddr: string): boolean {
+  const addressType = getAddressTypeOrThrow(hrefAddr);
+  if (isAddressTypeCaseSensitive(addressType)) {
+    return isAbbreviation(textToLookup, hrefAddr);
+  }
+
+  return isAbbreviation(textToLookup.toLowerCase(), hrefAddr.toLowerCase());
+}
+
 // Check whether the text node or its parent (if an <a href="...">) has
 // a full address.  If they both do, ensure that they match otherwise
 // warn the user that something fishy is probably going on.
@@ -154,7 +164,7 @@ export function replaceOnTextNode(node: Node, labelMap: LabelMap): number {
     return replaceText(node, data.label, before, after);
   }
 
-  if (!isAbbreviation(textToLookup.toLowerCase(), hrefAddr.toLowerCase())) {
+  if (!textMatchesLinkedAddress(textToLookup, hrefAddr)) {
     // They didn't match, so just ignore the href address
     return replaceText(node, data.label, before, after);
   }

--- a/src/shared/abbreviators.test.ts
+++ b/src/shared/abbreviators.test.ts
@@ -1,8 +1,14 @@
-import { abbreviatedAddresses, isAbbreviation, krakenAbbreviation } from './abbreviators';
+import {
+  abbreviatedEVMAddresses,
+  abbreviatedSolanaAddresses,
+  isAbbreviation,
+  krakenAbbreviation,
+} from './abbreviators';
 
 const FULL_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+const SOLANA_ADDRESS = 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK';
 
-const EXPECTED_ABBREVIATIONS = [
+const EXPECTED_ETH_ABBREVIATIONS = [
   '0x6B175474...1d0F',
   '0x6B175474E8...1d0F',
   '0x6B1754...271d0F',
@@ -18,7 +24,14 @@ const EXPECTED_ABBREVIATIONS = [
   '0x6B175474E89094C44Da98b954EedeA',
 ];
 
-const INVALID_ABBREVIATIONS = [
+const EXPECTED_SOLANA_ABBREVIATIONS = [
+  'DYw8jCTfwH...KUmG5CNSKK',
+  'DYw8jC...5CNSKK',
+  'DYw8j...CNSKK',
+  'DYw8...NSKK',
+];
+
+const INVALID_ETH_ABBREVIATIONS = [
   '0x6B175474...1d0',
   '0xB175474E8...1d0F',
   '0x6B7...1d0F',
@@ -33,10 +46,32 @@ const INVALID_ABBREVIATIONS = [
   'foobar',
 ];
 
-describe('abbreviatedAddresses()', () => {
+const INVALID_SOLANA_ABBREVIATIONS = [
+  'DYw8jCTfwH...UmG5CNSK',
+  'DYw8jC...5CNSKKK',
+  'DYw8j...CNSK',
+  'DYw8...NSK',
+  'DYw8jCTfwH..UmG5CNSKK',
+  'dyw8jCTfwH...UmG5CNSKK',
+  'DYw8jCTfwH...',
+  '...UmG5CNSKK',
+  'DYw8jCTfwH...UmG5CNSKKK',
+  'DYw8jCTfwH...UmG5CNSK',
+  '',
+  'foobar',
+];
+
+describe('abbreviatedEVMAddresses()', () => {
   it('outputs an array of abbreviated addresses', () => {
-    const abbrevs = abbreviatedAddresses(FULL_ADDRESS);
-    expect(abbrevs).toEqual(EXPECTED_ABBREVIATIONS);
+    const abbrevs = abbreviatedEVMAddresses(FULL_ADDRESS);
+    expect(abbrevs).toEqual(EXPECTED_ETH_ABBREVIATIONS);
+  });
+});
+
+describe('abbreviatedSolanaAddresses()', () => {
+  it('outputs an array of abbreviated Solana addresses', () => {
+    const abbrevs = abbreviatedSolanaAddresses(SOLANA_ADDRESS);
+    expect(abbrevs).toEqual(EXPECTED_SOLANA_ABBREVIATIONS);
   });
 });
 
@@ -47,7 +82,7 @@ describe('krakenAbbreviation()', () => {
 });
 
 describe('isAbbreviation()', () => {
-  for (const abbrev of EXPECTED_ABBREVIATIONS) {
+  for (const abbrev of EXPECTED_ETH_ABBREVIATIONS) {
     it(`detects ${abbrev} as a valid abbreviation of ${FULL_ADDRESS}`, () => {
       expect(isAbbreviation(abbrev, FULL_ADDRESS)).toBe(true);
     });
@@ -61,7 +96,21 @@ describe('isAbbreviation()', () => {
     });
   }
 
-  for (const abbrev of INVALID_ABBREVIATIONS) {
+  for (const abbrev of EXPECTED_SOLANA_ABBREVIATIONS) {
+    it(`detects ${abbrev} as a valid Solana abbreviation of ${SOLANA_ADDRESS}`, () => {
+      expect(isAbbreviation(abbrev, SOLANA_ADDRESS)).toBe(true);
+    });
+
+    it(`detects ${abbrev.toLowerCase()} as a valid Solana abbreviation of ${SOLANA_ADDRESS.toLowerCase()}`, () => {
+      expect(isAbbreviation(abbrev.toLowerCase(), SOLANA_ADDRESS.toLowerCase())).toBe(true);
+    });
+
+    it(`detects ${abbrev.toLowerCase()} as an invalid Solana abbreviation of ${SOLANA_ADDRESS}`, () => {
+      expect(isAbbreviation(abbrev.toLowerCase(), SOLANA_ADDRESS)).toBe(false);
+    });
+  }
+
+  for (const abbrev of INVALID_ETH_ABBREVIATIONS) {
     it(`detects ${abbrev} as an invalid abbreviation of ${FULL_ADDRESS}`, () => {
       expect(isAbbreviation(abbrev, FULL_ADDRESS)).toBe(false);
     });
@@ -70,4 +119,10 @@ describe('isAbbreviation()', () => {
   it('recognizes Kraken-style abbreviations', () => {
     expect(isAbbreviation('0x6B 1754 ... 9527 1d0F', FULL_ADDRESS)).toBe(true);
   });
+
+  for (const abbrev of INVALID_SOLANA_ABBREVIATIONS) {
+    it(`detects ${abbrev} as an invalid Solana abbreviation of ${SOLANA_ADDRESS}`, () => {
+      expect(isAbbreviation(abbrev, SOLANA_ADDRESS)).toBe(false);
+    });
+  }
 });

--- a/src/shared/abbreviators.ts
+++ b/src/shared/abbreviators.ts
@@ -1,4 +1,6 @@
-const ABBREVIATION_LENGTHS = [
+import { AddressType } from './types';
+
+const ABBREVIATION_LENGTHS_EVM = [
   // On many sites (e.g. Tenderly, defender.openzeppelin.com, Gnosis
   // Safe), addresses are abbreviated in the form 0x12345678...1234
   [8, 4],
@@ -57,8 +59,26 @@ const ABBREVIATION_LENGTHS = [
   [30, 0],
 ];
 
-export function abbreviatedAddresses(address: string): string[] {
-  return ABBREVIATION_LENGTHS.map(
+const ABBREVIATION_LENGTHS_SOLANA = [
+  // On solscan.io, addresses are abbreviated in the form
+  // 1234567890...1234567890
+  [10, 10],
+
+  // On raydium.io, addresses in the token selection modal are abbreviated
+  // in the form 123456...123456
+  [6, 6],
+
+  // On jup.ag, addresses in the token selection modal are abbreviated
+  // in the form 12345...12345
+  [5, 5],
+
+  // On meteora.ag, addresses in the pool creation page are abbreviated
+  // in the form 1234...1234
+  [4, 4],
+];
+
+export function abbreviatedEVMAddresses(address: string): string[] {
+  return ABBREVIATION_LENGTHS_EVM.map(
     ([left, right]: [number, number]) =>
       address.slice(0, left + 2) + (right === 0 ? '' : '...' + address.slice(-right)),
   );
@@ -69,10 +89,19 @@ export function krakenAbbreviation(address: string): string {
   return `0x${trimmed.slice(0, 2)} ${trimmed.slice(2, 6)} ... ${trimmed.slice(-8, -4)} ${trimmed.slice(-4)}`;
 }
 
-export const ABBREVIATION_FUNCTIONS = [
-  abbreviatedAddresses,
-  (addr: string) => [krakenAbbreviation(addr)],
-];
+export function abbreviatedSolanaAddresses(address: string): string[] {
+  return ABBREVIATION_LENGTHS_SOLANA.map(
+    ([left, right]: [number, number]) =>
+      address.slice(0, left) + (right === 0 ? '' : '...' + address.slice(-right)),
+  );
+}
+
+export type AbbreviationFunc = (address: string) => string[];
+
+export const ABBREVIATION_FUNCTIONS: Record<AddressType, AbbreviationFunc[]> = {
+  [AddressType.EVM]: [abbreviatedEVMAddresses, (addr: string) => [krakenAbbreviation(addr)]],
+  [AddressType.Solana]: [abbreviatedSolanaAddresses],
+};
 
 const isKrakenAbbreviation = (abbreviation: string, fullAddress: string): boolean => {
   const krakenMatch = abbreviation.match(
@@ -98,7 +127,20 @@ const isStandardEVMAbbreviation = (abbreviation: string, fullAddress: string): b
   return fullAddress.startsWith(start) && fullAddress.endsWith(end || '');
 };
 
-const ABBREVIATION_MATCHERS = [isKrakenAbbreviation, isStandardEVMAbbreviation];
+const isSolanaAbbreviation = (abbreviation: string, fullAddress: string): boolean => {
+  const solanaMatch = abbreviation.match(
+    /^([1-9A-HJ-NP-Za-km-z]+)(?:\.\.\.([1-9A-HJ-NP-Za-km-z]+))?$/,
+  );
+  if (!solanaMatch) return false;
+  const [, start, end] = solanaMatch;
+  return fullAddress.startsWith(start) && fullAddress.endsWith(end || '');
+};
+
+const ABBREVIATION_MATCHERS = [
+  isKrakenAbbreviation,
+  isStandardEVMAbbreviation,
+  isSolanaAbbreviation,
+];
 
 export function isAbbreviation(abbreviation: string, fullAddress: string): boolean {
   for (const fn of ABBREVIATION_MATCHERS) {

--- a/src/shared/address-type.test.ts
+++ b/src/shared/address-type.test.ts
@@ -1,0 +1,12 @@
+import { AddressType } from './types';
+import { isAddressTypeCaseSensitive } from './address-type';
+
+describe('isAddressTypeCaseSensitive', () => {
+  it('returns false for EVM', () => {
+    expect(isAddressTypeCaseSensitive(AddressType.EVM)).toBe(false);
+  });
+
+  it('returns true for Solana', () => {
+    expect(isAddressTypeCaseSensitive(AddressType.Solana)).toBe(true);
+  });
+});

--- a/src/shared/address-type.ts
+++ b/src/shared/address-type.ts
@@ -1,0 +1,29 @@
+import { RE_EVM_ADDRESS, RE_EVM_BYTES32, RE_SOLANA_ADDRESS } from './regexps';
+import { AddressType } from './types';
+
+export function isAddressTypeCaseSensitive(addressType: AddressType): boolean {
+  switch (addressType) {
+    case AddressType.EVM:
+      return false;
+    case AddressType.Solana:
+      return true;
+  }
+}
+
+export function getAddressType(address: string): AddressType | null {
+  if (RE_EVM_ADDRESS.test(address) || RE_EVM_BYTES32.test(address)) {
+    return AddressType.EVM;
+  }
+  if (RE_SOLANA_ADDRESS.test(address)) {
+    return AddressType.Solana;
+  }
+  return null;
+}
+
+export function getAddressTypeOrThrow(address: string): AddressType {
+  const addressType = getAddressType(address);
+  if (!addressType) {
+    throw new Error(`BUG: could not determine address type for '${address}'`);
+  }
+  return addressType;
+}

--- a/src/shared/address.ts
+++ b/src/shared/address.ts
@@ -1,11 +1,18 @@
 import { getAddress } from 'ethers';
+import { isAddress as isSolanaAddress } from '@solana/addresses';
 
 export function getCanonicalAddress(address: string): string | null {
   try {
-    if (typeof address !== 'string' || !address.startsWith('0x')) {
+    if (typeof address !== 'string') {
       return null;
     }
-    return getAddress(address);
+    if (address.startsWith('0x')) {
+      return getAddress(address);
+    }
+    if (isSolanaAddress(address)) {
+      return address;
+    }
+    return null;
   } catch (err: unknown) {
     return null;
   }

--- a/src/shared/formatter.test.ts
+++ b/src/shared/formatter.test.ts
@@ -1,42 +1,63 @@
 import { Formatter } from './formatter';
 
-const addr = '0xe3D82337F79306712477b642EF59B75dD62eF109';
 const label = 'my address label';
 
 describe('Formatter', () => {
-  it('formats a label with no changes', () => {
-    const formatter = new Formatter('%n');
-    expect(formatter.format(label, addr)).toEqual(label);
-  });
+  const testCases = [
+    { name: 'evm address with 0x prefix', addr: '0xe3D82337F79306712477b642EF59B75dD62eF109' },
+    { name: 'evm address without 0x prefix', addr: 'e3D82337F79306712477b642EF59B75dD62eF109' },
+    { name: 'solana address', addr: 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK' },
+  ];
 
-  it('formats a label with some parentheses', () => {
-    const formatter = new Formatter('[%n]');
-    expect(formatter.format(label, addr)).toEqual('[' + label + ']');
-  });
+  testCases.forEach(({ name, addr }) => {
+    describe(name, () => {
+      it('formats a label with no changes', () => {
+        const formatter = new Formatter('%n');
+        expect(formatter.format(label, addr)).toEqual(label);
+      });
 
-  it('formats a label with leading digits', () => {
-    const formatter = new Formatter('<%n | 0x%6l>');
-    expect(formatter.format(label, addr)).toEqual(`<${label} | 0xe3D823>`);
-  });
+      it('formats a label with some parentheses', () => {
+        const formatter = new Formatter('[%n]');
+        expect(formatter.format(label, addr)).toEqual('[' + label + ']');
+      });
 
-  it('formats a label with trailing digits', () => {
-    const formatter = new Formatter('%n | %4r');
-    expect(formatter.format(label, addr)).toEqual(`${label} | F109`);
-  });
+      it('formats a label with leading digits', () => {
+        const formatter = new Formatter('<%n | %6l>');
+        const trimmed = addr.replace(/^0x/, '');
+        const prefix = addr.startsWith('0x') ? '0x' : '';
+        const expected = `<${label} | ${prefix}${trimmed.slice(0, 6)}>`;
+        expect(formatter.format(label, addr)).toEqual(expected);
+      });
 
-  it('formats a label with leading and trailing digits', () => {
-    const formatter = new Formatter('0x%4l...%n...%4r');
-    expect(formatter.format(label, addr)).toEqual(`0xe3D8...${label}...F109`);
-  });
+      it('formats a label with trailing digits', () => {
+        const formatter = new Formatter('%n | %4r');
+        const trimmed = addr.replace(/^0x/, '');
+        expect(formatter.format(label, addr)).toEqual(`${label} | ${trimmed.slice(-4)}`);
+      });
 
-  it('formats a label with a full address', () => {
-    const formatter = new Formatter('%n (%a)');
-    expect(formatter.format(label, addr)).toEqual(`${label} (${addr})`);
-  });
+      it('formats a label with leading and trailing digits', () => {
+        const formatter = new Formatter('%4l...%n...%4r');
+        const trimmed = addr.replace(/^0x/, '');
+        const prefix = addr.startsWith('0x') ? '0x' : '';
+        expect(formatter.format(label, addr)).toEqual(
+          `${prefix}${trimmed.slice(0, 4)}...${label}...${trimmed.slice(-4)}`,
+        );
+      });
 
-  it('formats a label combining internal digits with other formats', () => {
-    // Test the format used by Kraken
-    const formatter = new Formatter('0x%2l %2i4 ... %-8i4 %4r');
-    expect(formatter.format(label, addr)).toEqual('0xe3 D823 ... D62e F109');
+      it('formats a label with a full address', () => {
+        const formatter = new Formatter('%n (%a)');
+        expect(formatter.format(label, addr)).toEqual(`${label} (${addr})`);
+      });
+    });
+
+    it('formats a label combining internal digits with other formats', () => {
+      // Test the format used by Kraken
+      const formatter = new Formatter('%2l %2i4 ... %-8i4 %4r');
+      const trimmed = addr.replace(/^0x/, '');
+      const prefix = addr.startsWith('0x') ? '0x' : '';
+      expect(formatter.format(label, addr)).toEqual(
+        `${prefix}${trimmed.slice(0, 2)} ${trimmed.slice(2, 6)} ... ${trimmed.slice(-8, -4)} ${trimmed.slice(-4)}`,
+      );
+    });
   });
 });

--- a/src/shared/formatter.ts
+++ b/src/shared/formatter.ts
@@ -16,11 +16,23 @@ export class Formatter {
     return this.formatString
       .replace('%n', label)
       .replace('%a', address)
-      .replace(/%(\d+)l/, (_match, digits) => trimmed.slice(0, Number(digits)))
+      .replace(/%(\d+)l/, (_match, digits) => this.sliceAddressStart(address, Number(digits)))
       .replace(/%(\d+)r/, (_match, digits) => trimmed.slice(-Number(digits)))
       .replaceAll(/%(-?\d+)i(\d+)/g, (_match, offset, length) => {
         const startAt = Number(offset) < 0 ? trimmed.length + Number(offset) : Number(offset);
         return trimmed.slice(startAt, startAt + Number(length));
       });
+  }
+
+  // Slice the address from the start to the given number of digits.
+  // If the address starts with 0x, add it back to the sliced address.
+  sliceAddressStart(address: Address, digits: number): string {
+    let addressString = address.replace(/^0x/, '').slice(0, digits);
+
+    if (address.startsWith('0x')) {
+      addressString = '0x' + addressString;
+    }
+
+    return addressString;
   }
 }

--- a/src/shared/options-storage.test.ts
+++ b/src/shared/options-storage.test.ts
@@ -17,6 +17,9 @@ import {
   DEFAULT_OPTIONS_SERIALIZED,
   DEFAULT_OPTIONS_DESERIALIZED,
   migrateToSections,
+  migrateLegacyDisplayFormats,
+  LEGACY_DISPLAY_LABEL_FORMAT,
+  LEGACY_DISPLAY_GUESS_FORMAT,
   Rolod0xOptionsV1,
   deserializeOptions,
   validateDeserialized,
@@ -163,6 +166,36 @@ describe('options-storage', () => {
     });
   });
 
+  describe('migrateLegacyDisplayFormats', () => {
+    it('updates only the legacy default formats', () => {
+      const options = {
+        displayLabelFormat: LEGACY_DISPLAY_LABEL_FORMAT,
+        displayGuessFormat: LEGACY_DISPLAY_GUESS_FORMAT,
+      };
+
+      migrateLegacyDisplayFormats(options, DEFAULT_OPTIONS_SERIALIZED);
+
+      expect(options).toEqual({
+        displayLabelFormat: DEFAULT_OPTIONS_DESERIALIZED.displayLabelFormat,
+        displayGuessFormat: DEFAULT_OPTIONS_DESERIALIZED.displayGuessFormat,
+      });
+    });
+
+    it('preserves custom formats', () => {
+      const options = {
+        displayLabelFormat: '%n (%6l...%4r)',
+        displayGuessFormat: '[custom guess]',
+      };
+
+      migrateLegacyDisplayFormats(options, DEFAULT_OPTIONS_SERIALIZED);
+
+      expect(options).toEqual({
+        displayLabelFormat: '%n (%6l...%4r)',
+        displayGuessFormat: '[custom guess]',
+      });
+    });
+  });
+
   describe('DeserializableOptionsSync', () => {
     beforeEach(() => {
       mockGetAll.mockClear();
@@ -176,8 +209,8 @@ describe('options-storage', () => {
       const v1Options: Rolod0xOptionsV1 = {
         themeName: 'dark',
         labels,
-        displayLabelFormat: '%n (0x%4l…%4r)',
-        displayGuessFormat: '? %n ? (0x%4l…%4r)',
+        displayLabelFormat: LEGACY_DISPLAY_LABEL_FORMAT,
+        displayGuessFormat: LEGACY_DISPLAY_GUESS_FORMAT,
       };
       // Mock what getAll would actually return - a serialized version of the options
       mockGetAll.mockResolvedValue(v1Options);
@@ -197,8 +230,24 @@ describe('options-storage', () => {
       });
       expect(result.sections[0].id).toHaveLength(36); // UUID length
       expect(result.themeName).toBe('dark');
-      expect(result.displayLabelFormat).toBe('%n (0x%4l…%4r)');
-      expect(result.displayGuessFormat).toBe('? %n ? (0x%4l…%4r)');
+      expect(result.displayLabelFormat).toBe(DEFAULT_OPTIONS_DESERIALIZED.displayLabelFormat);
+      expect(result.displayGuessFormat).toBe(DEFAULT_OPTIONS_DESERIALIZED.displayGuessFormat);
+    });
+
+    it('preserves custom display formats during deserialization', async () => {
+      const customOptions: Rolod0xOptionsV1 = {
+        themeName: 'dark',
+        labels: '0xD3159eC8ABb2114812E65A87a5c28DA3841C7FD7 test address',
+        displayLabelFormat: '%n (%6l...%4r)',
+        displayGuessFormat: '[%n]',
+      };
+
+      mockGetAll.mockResolvedValue(customOptions);
+
+      const result = await optionsStorage.getAllDeserialized();
+
+      expect(result.displayLabelFormat).toBe(customOptions.displayLabelFormat);
+      expect(result.displayGuessFormat).toBe(customOptions.displayGuessFormat);
     });
 
     it('correctly serializes sections when setting options', async () => {

--- a/src/shared/options-storage.ts
+++ b/src/shared/options-storage.ts
@@ -103,8 +103,8 @@ export const labelsToSection = (labels: string): Rolod0xAddressBookSection => {
 export const DEFAULT_OPTIONS_DESERIALIZED: Rolod0xOptionsDeserialized = {
   themeName: 'light',
   sections: [labelsToSection('')],
-  displayLabelFormat: '%n (0x%4l…%4r)',
-  displayGuessFormat: '? %n ? (0x%4l…%4r)',
+  displayLabelFormat: '%n (%4l…%4r)',
+  displayGuessFormat: '? %n ? (%4l…%4r)',
   hasSeenTour: false,
 };
 

--- a/src/shared/options-storage.ts
+++ b/src/shared/options-storage.ts
@@ -61,6 +61,9 @@ export type Rolod0xOptionsSerialized = Omit<Rolod0xOptionsDeserialized, 'section
 
 type Rolod0xRawOptions = Rolod0xOptionsV1 | Rolod0xOptionsSerialized;
 
+export const LEGACY_DISPLAY_LABEL_FORMAT = '%n (0x%4l…%4r)';
+export const LEGACY_DISPLAY_GUESS_FORMAT = '? %n ? (0x%4l…%4r)';
+
 export const serializeOptions = (options: Rolod0xOptionsDeserialized): Rolod0xOptionsSerialized => {
   const { sections, ...rest } = options;
   return {
@@ -141,6 +144,19 @@ export const migrateToSections = (
   }
 };
 
+export const migrateLegacyDisplayFormats = (
+  options: Pick<Rolod0xRawOptions, 'displayLabelFormat' | 'displayGuessFormat'>,
+  _currentDefaults: Rolod0xOptionsSerialized,
+) => {
+  if (options.displayLabelFormat === LEGACY_DISPLAY_LABEL_FORMAT) {
+    options.displayLabelFormat = DEFAULT_OPTIONS_DESERIALIZED.displayLabelFormat;
+  }
+
+  if (options.displayGuessFormat === LEGACY_DISPLAY_GUESS_FORMAT) {
+    options.displayGuessFormat = DEFAULT_OPTIONS_DESERIALIZED.displayGuessFormat;
+  }
+};
+
 const isV1Options = (options: Rolod0xRawOptions): options is Rolod0xOptionsV1 => {
   return 'labels' in options;
 };
@@ -149,6 +165,7 @@ export class DeserializableOptionsSync extends OptionsSync<Rolod0xOptionsSeriali
   async getAllDeserialized(): Promise<Rolod0xOptionsDeserialized> {
     const raw = await this.getAll();
     const v2 = isV1Options(raw) ? mutateV1ToV2(raw) : raw;
+    migrateLegacyDisplayFormats(v2, DEFAULT_OPTIONS_SERIALIZED);
     return deserializeOptions(v2);
   }
 
@@ -216,7 +233,7 @@ export class DeserializableOptionsSync extends OptionsSync<Rolod0xOptionsSeriali
 
 export const optionsStorage = new DeserializableOptionsSync({
   defaults: DEFAULT_OPTIONS_SERIALIZED,
-  migrations: [migrateToSections, OptionsSync.migrations.removeUnused],
+  migrations: [migrateToSections, migrateLegacyDisplayFormats, OptionsSync.migrations.removeUnused],
   logging: true,
   storageType: 'local',
 });

--- a/src/shared/parser.test.ts
+++ b/src/shared/parser.test.ts
@@ -252,4 +252,99 @@ describe('Parser', () => {
     ]);
     expect(parser.duplicates).toEqual(['0xe3D82337F79306712477b642EF59B75dD62eF109']);
   });
+
+  it('parses a single Solana address', () => {
+    const parser = new Parser(
+      'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK my solana label // comment',
+    );
+    expect(parser.parsedEntries).toEqual([
+      {
+        address: 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK',
+        label: 'my solana label',
+        comment: 'comment',
+      },
+    ]);
+  });
+
+  it('parses a Solana address with leading whitespace', () => {
+    const parser = new Parser(
+      '      DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK my solana label // comment',
+    );
+    expect(parser.parsedEntries).toEqual([
+      {
+        address: 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK',
+        label: 'my solana label',
+        comment: 'comment',
+      },
+    ]);
+  });
+
+  it('parses mixed EVM and Solana addresses', () => {
+    const parser = new Parser(dedent`
+      0x1803982898d6a8E832177Fca8fD763B9060C3050 evm label // evm comment
+      DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK solana label // sol comment
+    `);
+    expect(parser.parsedEntries).toEqual([
+      {
+        address: '0x1803982898d6a8E832177Fca8fD763B9060C3050',
+        label: 'evm label',
+        comment: 'evm comment',
+      },
+      {
+        address: 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK',
+        label: 'solana label',
+        comment: 'sol comment',
+      },
+    ]);
+  });
+
+  it('parses multiple Solana addresses of various types', () => {
+    const parser = new Parser(dedent`
+      7vJ3mSPgKnnHSyHx5JKnwqL4gYbEuGBJ4KXJGE9kBUkj wallet address // personal wallet
+      5TeGDBFiXs3YtGzg5MQKp7PVxgpm5TxqHMxGsiBKp5dB program v1
+      TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA token program // SPL token
+      ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL associated token // ATA program
+    `);
+    expect(parser.parsedEntries).toEqual([
+      {
+        address: '7vJ3mSPgKnnHSyHx5JKnwqL4gYbEuGBJ4KXJGE9kBUkj',
+        label: 'wallet address',
+        comment: 'personal wallet',
+      },
+      {
+        address: '5TeGDBFiXs3YtGzg5MQKp7PVxgpm5TxqHMxGsiBKp5dB',
+        label: 'program v1',
+        comment: undefined,
+      },
+      {
+        address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        label: 'token program',
+        comment: 'SPL token',
+      },
+      {
+        address: 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+        label: 'associated token',
+        comment: 'ATA program',
+      },
+    ]);
+  });
+
+  it('treats a lowercased Solana address as distinct from the mixed-case address', () => {
+    const parser = new Parser(dedent`
+      TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA token program mixed case
+      tokenkegqfezyinwajbnbgkpfxcwubvf9ss623vq5da token program lowercase
+    `);
+    expect(parser.parsedEntries).toEqual([
+      {
+        address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+        label: 'token program mixed case',
+        comment: undefined,
+      },
+      {
+        address: 'tokenkegqfezyinwajbnbgkpfxcwubvf9ss623vq5da',
+        label: 'token program lowercase',
+        comment: undefined,
+      },
+    ]);
+  });
 });

--- a/src/shared/parser.test.ts
+++ b/src/shared/parser.test.ts
@@ -67,6 +67,20 @@ describe('Parser', () => {
     ]);
   });
 
+  it('parses an EVM entry with leading whitespace', () => {
+    const parser = new Parser(dedent`
+      // foo bar
+            0x1803982898d6a8E832177Fca8fD763B9060C3050 my label
+    `);
+    expect(parser.parsedEntries).toEqual([
+      {
+        address: '0x1803982898d6a8E832177Fca8fD763B9060C3050',
+        label: 'my label',
+        comment: undefined,
+      },
+    ]);
+  });
+
   it('parses a single lowercase entry', () => {
     const parser = new Parser(dedent`
       // foo bar

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -30,43 +30,46 @@ export class Parser {
   }
 
   parseMultiline(unparsedLabels: string): ParsedEntries {
-    const labelLineRe = /^s*(0x[\da-f]{40})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/i;
     const lines = unparsedLabels.split('\n');
-    lines.forEach((line, i) => {
-      if (/^\s*(\/\/|$)/.test(line)) {
-        // Comment or blank line; ignore
+    lines.forEach((line, lineIndex) => {
+      this.parseLine(line, lineIndex);
+    });
+    return this.parsedEntries;
+  }
+
+  private parseLine(line: string, lineIndex: number): void {
+    if (/^\s*(\/\/|$)/.test(line)) {
+      // Comment or blank line; ignore
+      return;
+    }
+
+    const labelLineRe = /^s*(0x[\da-f]{40})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/i;
+    const m = labelLineRe.exec(line);
+    if (m) {
+      const [_all, address, label, comment] = m;
+      if (address && label) {
+        let canonical: string;
+        try {
+          canonical = getAddress(address);
+        } catch (err: unknown) {
+          if (err instanceof Error && err.message.match(/bad address checksum/)) {
+            throw new ParseError(lineIndex + 1, `Bad address checksum`);
+          }
+          throw err;
+        }
+        this.addEntry(canonical, label, comment);
         return;
       }
 
-      const m = labelLineRe.exec(line);
-      if (m) {
-        const [_all, address, label, comment] = m;
-        if (address && label) {
-          let canonical: string;
-          try {
-            canonical = getAddress(address);
-          } catch (err: unknown) {
-            if (err instanceof Error && err.message.match(/bad address checksum/)) {
-              throw new ParseError(i + 1, `Bad address checksum`);
-            }
-            throw err;
-          }
-          this.addEntry(canonical, label, comment);
-          return;
-        }
+      throw new Error(
+        `BUG: parsing issue with line ${lineIndex + 1}; ` +
+          `address=${address ?? 'undefined'}, ` +
+          `label=${label ?? 'undefined'}:\n` +
+          line,
+      );
+    }
 
-        throw new Error(
-          `BUG: parsing issue with line ${i + 1}; ` +
-            `address=${address ?? 'undefined'}, ` +
-            `label=${label ?? 'undefined'}:\n` +
-            line,
-        );
-      }
-
-      throw new ParseError(i + 1);
-    });
-
-    return this.parsedEntries;
+    throw new ParseError(lineIndex + 1);
   }
 
   addEntry(address: Address, label: Label, comment?: Comment): void {

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -57,13 +57,11 @@ export class Parser {
     throw new ParseError(lineIndex + 1);
   }
 
-  private parseEVMLine(line: string, lineIndex: number): boolean {
-    const labelLineRe = /^s*(0x[\da-f]{40})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/i;
-    const m = labelLineRe.exec(line);
-    if (!m) {
-      return false;
-    }
-
+  private parseLineParts(
+    m: RegExpExecArray,
+    line: string,
+    lineIndex: number,
+  ): [string, string, string | undefined] {
     const [_all, address, label, comment] = m;
     if (!address || !label) {
       throw new Error(
@@ -73,6 +71,17 @@ export class Parser {
           line,
       );
     }
+    return [address, label, comment];
+  }
+
+  private parseEVMLine(line: string, lineIndex: number): boolean {
+    const labelLineRe = /^s*(0x[\da-f]{40})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/i;
+    const m = labelLineRe.exec(line);
+    if (!m) {
+      return false;
+    }
+
+    const [address, label, comment] = this.parseLineParts(m, line, lineIndex);
 
     let canonical: string;
     try {
@@ -95,15 +104,7 @@ export class Parser {
       return false;
     }
 
-    const [_all, address, label, comment] = m;
-    if (!address || !label) {
-      throw new Error(
-        `BUG: parsing issue with line ${lineIndex + 1}; ` +
-          `address=${address ?? 'undefined'}, ` +
-          `label=${label ?? 'undefined'}:\n` +
-          line,
-      );
-    }
+    const [address, label, comment] = this.parseLineParts(m, line, lineIndex);
 
     const isSolanaAddress = isAddress(address);
     if (!isSolanaAddress) {

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -1,4 +1,5 @@
 import { getAddress } from 'ethers';
+import { isAddress } from '@solana/addresses';
 
 import { Address, Label, Comment, ParsedEntries } from './types';
 
@@ -48,6 +49,11 @@ export class Parser {
       return;
     }
 
+    const isSolana = this.parseSolanaLine(line, lineIndex);
+    if (isSolana) {
+      return;
+    }
+
     throw new ParseError(lineIndex + 1);
   }
 
@@ -79,6 +85,31 @@ export class Parser {
     }
 
     this.addEntry(canonical, label, comment);
+    return true;
+  }
+
+  private parseSolanaLine(line: string, lineIndex: number): boolean {
+    const labelLineRe = /^\s*([1-9A-HJ-NP-Za-km-z]{32,44})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/;
+    const m = labelLineRe.exec(line);
+    if (!m) {
+      return false;
+    }
+
+    const [_all, address, label, comment] = m;
+    if (!address || !label) {
+      throw new Error(
+        `BUG: parsing issue with line ${lineIndex + 1}; ` +
+          `address=${address ?? 'undefined'}, ` +
+          `label=${label ?? 'undefined'}:\n` +
+          line,
+      );
+    }
+
+    const isSolanaAddress = isAddress(address);
+    if (!isSolanaAddress) {
+      throw new ParseError(lineIndex + 1, 'Invalid Solana address');
+    }
+    this.addEntry(address, label, comment);
     return true;
   }
 

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -75,7 +75,7 @@ export class Parser {
   }
 
   private parseEVMLine(line: string, lineIndex: number): boolean {
-    const labelLineRe = /^s*(0x[\da-f]{40})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/i;
+    const labelLineRe = /^\s*(0x[\da-f]{40})\s+(.+?)(?:\s+\/\/\s*(.*?)\s*)?$/i;
     const m = labelLineRe.exec(line);
     if (!m) {
       return false;

--- a/src/shared/regexps.test.ts
+++ b/src/shared/regexps.test.ts
@@ -1,6 +1,11 @@
-import { RE_ADDRESS, RE_BYTES32, RE_ADDRESS_OR_BYTES32 } from './regexps';
+import {
+  RE_EVM_ADDRESS,
+  RE_EVM_BYTES32,
+  RE_EVM_ADDRESS_OR_BYTES32,
+  RE_SOLANA_ADDRESS,
+} from './regexps';
 
-const ADDRESS_MATCHES = [
+const EVM_ADDRESS_MATCHES = [
   ['0x6b175474e89094c44da98b954eedeac495271d0f', 'a lowercase address'],
   ['foo 0x6b175474e89094c44da98b954eedeac495271d0f bar', 'a surrounded lowercase address'],
 
@@ -8,7 +13,7 @@ const ADDRESS_MATCHES = [
   ['foo 0x6B175474E89094C44Da98b954EedeAC495271d0F bar', 'matches a mixed case address'],
 ];
 
-const ADDRESS_NON_MATCHES = [
+const EVM_ADDRESS_NON_MATCHES = [
   [
     'foo0x6B175474E89094C44Da98b954EedeAC495271d0',
     "doesn't match an address immediately following alphanumerics",
@@ -25,7 +30,7 @@ const ADDRESS_NON_MATCHES = [
   ['foo 0x6B175474E89094C44Da98b954EedeAC495271d0F1 bar', "doesn't match an extended address"],
 ];
 
-const BYTES32_MATCHES = [
+const EVM_BYTES32_MATCHES = [
   [
     '0x6b175474e89094c44da98b954eedeac495271d0f012345678901234567890123',
     'a lowercase 32-byte value',
@@ -61,7 +66,7 @@ const BYTES32_MATCHES = [
   ],
 ];
 
-const BYTES32_NON_MATCHES = [
+const EVM_BYTES32_NON_MATCHES = [
   [
     'foo0x6B175474E89094C44Da98b954EedeAC495271d0F012345678901234567890123 bar',
     "doesn't match a 32-byte value immediately following alphanumerics",
@@ -87,44 +92,74 @@ const BYTES32_NON_MATCHES = [
   ],
 ];
 
-describe('RE_ADDRESS', () => {
-  for (const [input, descr] of ADDRESS_MATCHES) {
+const SOLANA_MATCHES = [
+  ['DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK', 'a standard Solana address'],
+  ['foo DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK bar', 'a surrounded Solana address'],
+  ['TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', 'the SPL token program ID'],
+  ['ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL', 'the ATA program ID'],
+];
+
+const SOLANA_NON_MATCHES = [
+  ['abcd', 'too short'],
+  ['DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK1', 'too long'],
+  ['DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSK0', 'contains invalid character 0'],
+  ['DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKl', 'contains invalid character l'],
+  ['DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKI', 'contains invalid character I'],
+  ['DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKOO', 'contains invalid character O'],
+];
+
+describe('RE_EVM_ADDRESS', () => {
+  for (const [input, descr] of EVM_ADDRESS_MATCHES) {
     it(`matches ${descr}`, () => {
-      expect(input).toMatch(RE_ADDRESS);
+      expect(input).toMatch(RE_EVM_ADDRESS);
     });
   }
 
-  for (const [input, descr] of ADDRESS_NON_MATCHES) {
+  for (const [input, descr] of EVM_ADDRESS_NON_MATCHES) {
     it(`doesn't match ${descr}`, () => {
-      expect(input).not.toMatch(RE_ADDRESS);
+      expect(input).not.toMatch(RE_EVM_ADDRESS);
     });
   }
 });
 
-describe('RE_BYTES32', () => {
-  for (const [input, descr] of BYTES32_MATCHES) {
+describe('RE_EVM_BYTES32', () => {
+  for (const [input, descr] of EVM_BYTES32_MATCHES) {
     it(`matches ${descr}`, () => {
-      expect(input).toMatch(RE_BYTES32);
+      expect(input).toMatch(RE_EVM_BYTES32);
     });
   }
 
-  for (const [input, descr] of BYTES32_NON_MATCHES) {
+  for (const [input, descr] of EVM_BYTES32_NON_MATCHES) {
     it(`doesn't match ${descr}`, () => {
-      expect(input).not.toMatch(RE_BYTES32);
+      expect(input).not.toMatch(RE_EVM_BYTES32);
     });
   }
 });
 
-describe('RE_ADDRESS_OR_BYTES32', () => {
-  for (const [input, descr] of [...ADDRESS_MATCHES, ...BYTES32_MATCHES]) {
+describe('RE_SOLANA_ADDRESS', () => {
+  for (const [input, descr] of SOLANA_MATCHES) {
     it(`matches ${descr}`, () => {
-      expect(input).toMatch(RE_ADDRESS_OR_BYTES32);
+      expect(input).toMatch(RE_SOLANA_ADDRESS);
     });
   }
 
-  for (const [input, descr] of [...ADDRESS_NON_MATCHES, ...BYTES32_NON_MATCHES]) {
+  for (const [input, descr] of SOLANA_NON_MATCHES) {
     it(`doesn't match ${descr}`, () => {
-      expect(input).not.toMatch(RE_ADDRESS_OR_BYTES32);
+      expect(input).not.toMatch(RE_SOLANA_ADDRESS);
+    });
+  }
+});
+
+describe('RE_EVM_ADDRESS_OR_BYTES32', () => {
+  for (const [input, descr] of [...EVM_ADDRESS_MATCHES, ...EVM_BYTES32_MATCHES]) {
+    it(`matches ${descr}`, () => {
+      expect(input).toMatch(RE_EVM_ADDRESS_OR_BYTES32);
+    });
+  }
+
+  for (const [input, descr] of [...EVM_ADDRESS_NON_MATCHES, ...EVM_BYTES32_NON_MATCHES]) {
+    it(`doesn't match ${descr}`, () => {
+      expect(input).not.toMatch(RE_EVM_ADDRESS_OR_BYTES32);
     });
   }
 });

--- a/src/shared/regexps.ts
+++ b/src/shared/regexps.ts
@@ -1,9 +1,8 @@
 // EVM regexps
-export const RE_EVM_ADDRESS = /0x[0-9a-f]{40}\b/i;
-export const RE_EVM_BYTES32 = /\b(0x)?[0-9a-f]{64}\b/i;
+export const RE_EVM_ADDRESS = /0x[0-9a-fA-F]{40}\b/;
+export const RE_EVM_BYTES32 = /\b(0x)?[0-9a-fA-F]{64}\b/;
 export const RE_EVM_ADDRESS_OR_BYTES32 = new RegExp(
   `(${RE_EVM_ADDRESS.source}|${RE_EVM_BYTES32.source})`,
-  'i',
 );
 
 // Solana regexps

--- a/src/shared/regexps.ts
+++ b/src/shared/regexps.ts
@@ -1,3 +1,18 @@
-export const RE_ADDRESS = /0x[0-9a-f]{40}\b/i;
-export const RE_BYTES32 = /\b(0x)?[0-9a-f]{64}\b/i;
-export const RE_ADDRESS_OR_BYTES32 = new RegExp(`(${RE_ADDRESS.source}|${RE_BYTES32.source})`, 'i');
+// EVM regexps
+export const RE_EVM_ADDRESS = /0x[0-9a-f]{40}\b/i;
+export const RE_EVM_BYTES32 = /\b(0x)?[0-9a-f]{64}\b/i;
+export const RE_EVM_ADDRESS_OR_BYTES32 = new RegExp(
+  `(${RE_EVM_ADDRESS.source}|${RE_EVM_BYTES32.source})`,
+  'i',
+);
+
+// Solana regexps
+export const RE_SOLANA_ADDRESS = /\b[1-9A-HJ-NP-Za-km-z]{32,44}\b/;
+
+// Combined regexps
+export const RE_ADDRESS_FORMATS = new RegExp(
+  `(${RE_EVM_ADDRESS.source}|${RE_SOLANA_ADDRESS.source})`,
+);
+export const RE_ADDRESSES_OR_BYTES32 = new RegExp(
+  `(${RE_EVM_ADDRESS.source}|${RE_EVM_BYTES32.source}|${RE_SOLANA_ADDRESS.source})`,
+);

--- a/src/shared/transformers.test.ts
+++ b/src/shared/transformers.test.ts
@@ -1,7 +1,7 @@
 import { zeroPaddedAddress } from './transformers';
 
 describe('zeroPaddedAddress', () => {
-  it('outputs an array of four zero-padded addresses', () => {
+  it('outputs an array of two zero-padded addresses', () => {
     expect(zeroPaddedAddress('0x6B175474E89094C44Da98b954EedeAC495271d0F')).toEqual([
       '0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',
       '0x0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',

--- a/src/shared/transformers.test.ts
+++ b/src/shared/transformers.test.ts
@@ -7,4 +7,8 @@ describe('zeroPaddedAddress', () => {
       '0x0000000000000000000000006B175474E89094C44Da98b954EedeAC495271d0F',
     ]);
   });
+
+  it('outputs an empty array for an invalid address', () => {
+    expect(zeroPaddedAddress('DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK')).toEqual([]);
+  });
 });

--- a/src/shared/transformers.ts
+++ b/src/shared/transformers.ts
@@ -1,6 +1,11 @@
+import { RE_EVM_ADDRESS } from './regexps';
+
 // Spot addresses embedded into EVM 256 bit words.  This is typically
 // seen in event data.
 export function zeroPaddedAddress(address: string): string[] {
+  if (!RE_EVM_ADDRESS.test(address)) {
+    return [];
+  }
   // Addresses are 20 bytes, so to pad to 32 bytes we need an extra
   // 12 bytes of zero padding (24 nibbles).
   const padded = '00'.repeat(12) + address.slice(2);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,10 @@
 export type Label = string;
 export type Address = string;
 export type Comment = string;
+export enum AddressType {
+  EVM = 'EVM',
+  Solana = 'Solana',
+}
 
 export interface AddressLabel {
   address: Address;


### PR DESCRIPTION
Add support for labeling Solana addresses, which can be between 32-44 characters
and are Base58-encoded (using charset [1-9A-HJ-NP-Za-km-z]). Supports:
- Standard wallet addresses (32-byte public keys)
- Program Derived Addresses (PDAs)
- Program addresses (smart contracts)
- System Program address (32 ones)
- Associated Token Account addresses

Related issue: https://github.com/rolod0x/rolod0x/issues/419