### PR TITLE
fix(options-storage): fix migration from v1 labels

### DIFF
--- a/src/shared/options-storage.ts
+++ b/src/shared/options-storage.ts
@@ -126,7 +126,7 @@ export const migrateToSections = (
 ) => {
   console.llog('Checking migration to sections');
   // Check if sections exist and are valid JSON
-  if ('sections' in options) {
+  if (!isV1Options(options)) {
     console.llog('ℹ️ Already migrated old labels to section');
     return;
   }
@@ -216,7 +216,7 @@ export class DeserializableOptionsSync extends OptionsSync<Rolod0xOptionsSeriali
 
 export const optionsStorage = new DeserializableOptionsSync({
   defaults: DEFAULT_OPTIONS_SERIALIZED,
-  migrations: [OptionsSync.migrations.removeUnused, migrateToSections],
+  migrations: [migrateToSections, OptionsSync.migrations.removeUnused],
   logging: true,
   storageType: 'local',
 });


### PR DESCRIPTION
The `OptionsSync.migrations.removeUnused` migration was running before `migrateToSections`, which was removing labels before it could be migrated into a new section.  So swap the order of migrations.

Also to be safe from defaults, use `isV1Options()` to check for the presence of old labels and consider that as authoritative even if there are already new sections.

Closes #500.