### PR TITLE
ci(build-zip): don't nest firefox artifacts in subdirectory

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -80,7 +80,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           zip -r $RELEASE_NAME-chrome.zip rolod0x-chrome/
-          zip -r $RELEASE_NAME-firefox.zip rolod0x-firefox/*
+          cd rolod0x-firefox
+          zip -r ../$RELEASE_NAME-firefox.zip *
 
       - name: Create a draft release from a tag
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
It seems that the Mozilla Add-on Developer Hub expects files at
the top level of the zip.  b9a0f826 attempted to fix this but
failed.