### PR TITLE
improve CLI and `--duplicates` option

### DIFF
--- a/bin/rolod0x.sh
+++ b/bin/rolod0x.sh
@@ -2,4 +2,4 @@
 
 here="$(dirname $0)"
 
-"$here/../node_modules/.bin/tsx" "$here/../src/cli.ts" "$@"
+"$here/../node_modules/.bin/tsx" "$here/../src/cli/index.ts" "$@"

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -265,11 +265,42 @@ create a global alias:
 Then you can just append `0x` to the end of any command and it will
 pipe STDOUT and STDERR through rolod0x.
 
-### Listing duplicate labels
+### Finding duplicate addresses across files
 
-If you specify the `-d` or `--duplicates` option, then instead of
-filtering `STDIN`, it will list all addresses in the given address
-book file which have duplicate labels.
+The `--duplicates` option allows you to find addresses that appear in multiple address book files, which is useful for:
+
+- Identifying potential conflicts between different address books
+- Finding addresses with different labels across files
+- Discovering addresses that appear in multiple files with identical labels
+
+#### Basic usage
+
+To find duplicates across multiple files:
+
+    rolod0x --duplicates file1.txt file2.txt file3.txt
+
+This will show all addresses that appear in more than one file, along with their labels and which files contain them. For example:
+
+    0x1234...5678
+        Alice (~/addresses-personal.txt)
+        Alice Work Account (~/addresses-work.txt)
+        // My friend Alice (~/addresses-personal.txt)
+        // Different label for same person (~/addresses-work.txt)
+
+#### Filtering by file
+
+You can use `--dup-files-filter` (or `-D`) to only show duplicates where at least one label comes from a file matching a substring:
+
+    rolod0x --duplicates --dup-files-filter "work" *.txt
+
+This would only show duplicates that have at least one label from a file whose path contains "work".
+
+#### Case sensitivity handling
+
+The duplicate detection automatically handles case sensitivity by normalizing all addresses to EIP-55 checksum format, so these would be detected as the same address:
+
+- `0xe32bb999851587b53d170c0a130cce7f542c754d` (lowercase)
+- `0xE32bb999851587b53d170C0A130cCE7f542c754d` (mixed case)
 
 ## Importing token lists on the command line <a name="import-tokenlist"></a>
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint:ext": "web-ext lint -s dist/firefox",
     "tokenlist:import": "pnpm exec tsx ./src/import-tokenlist.ts",
     "prepare": "husky install",
-    "rolod0x": "pnpm exec tsx ./src/cli.ts",
+    "rolod0x": "pnpm exec tsx ./src/cli/index.ts",
     "website:prepare": "./scripts/website-prepare.sh"
   },
   "type": "module",

--- a/src/cli/duplicates.ts
+++ b/src/cli/duplicates.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs';
+
+import { Parser } from '../shared/parser';
+import { Address } from '../shared/types';
+import { fatal } from '../shared/utils';
+
+// Maps from text (label/comment) -> address -> set of files containing that text for that address
+// This complex nested structure is needed because:
+// 1. The same label can be used for different addresses (e.g., "Alice" for 0x123 and "Alice" for 0x456)
+// 2. The same address can have the same label in multiple files (e.g., "Uniswap" in both personal.txt and work.txt)
+// 3. We need to track which specific files contain each label/address combination for display purposes
+// Example: TextToFilesMap["Alice"][0x123] = Set{"personal.txt", "work.txt"}
+type TextToFilesMap = Map<string, Map<Address, Set<string>>>;
+
+// Stateful class for detecting and displaying duplicate addresses across multiple files
+class DuplicatesDetector {
+  private combinedParser = new Parser();
+  private labelToFiles: TextToFilesMap = new Map();
+  private commentToFiles: TextToFilesMap = new Map();
+  private addressFiles: string[] = [];
+
+  constructor(addressFiles: string[]) {
+    this.validateFiles(addressFiles);
+    this.addressFiles = addressFiles;
+    this.parseAndTrackFiles();
+  }
+
+  // Display duplicate addresses with optional file filtering
+  displayDuplicates(filesFilter?: string): void {
+    let first = true;
+    const duplicateAddresses = this.findCrossFileDuplicates();
+
+    for (const address of duplicateAddresses) {
+      if (filesFilter && !this.hasMatchingFile(address, filesFilter)) {
+        continue;
+      }
+
+      if (first) {
+        first = false;
+      } else {
+        console.log('');
+      }
+
+      this.displayDuplicateAddress(address);
+    }
+  }
+
+  private validateFiles(addressFiles: string[]): void {
+    for (const file of addressFiles) {
+      if (!fs.existsSync(file)) {
+        fatal(`File ${file} doesn't exist! Aborting.`);
+      }
+    }
+  }
+
+  // Parse all address files and build tracking maps to know which files contain each label/comment
+  private parseAndTrackFiles(): void {
+    for (const file of this.addressFiles) {
+      const content = fs.readFileSync(file).toString();
+      const fileParser = new Parser(content);
+
+      this.trackLabelsAndComments(fileParser, file);
+      this.combinedParser.parseMultiline(content);
+    }
+  }
+
+  // Track which files contain each label and comment for a given address
+  private trackLabelsAndComments(fileParser: Parser, file: string): void {
+    for (const address of fileParser.addresses) {
+      const labels = fileParser.labels[address] || [];
+      const comments = fileParser.comments[address] || [];
+
+      for (const label of labels) {
+        this.addToTracker(this.labelToFiles, label, address, file);
+      }
+
+      for (const comment of comments) {
+        this.addToTracker(this.commentToFiles, comment, address, file);
+      }
+    }
+  }
+
+  // Add a label/comment and its source file to the tracking data structure
+  private addToTracker(tracker: TextToFilesMap, key: string, address: Address, file: string): void {
+    if (!tracker.has(key)) {
+      tracker.set(key, new Map());
+    }
+    if (!tracker.get(key)!.has(address)) {
+      tracker.get(key)!.set(address, new Set());
+    }
+    tracker.get(key)!.get(address)!.add(file);
+  }
+
+  // Find addresses that appear in multiple files by analyzing label and comment file mappings
+  private findCrossFileDuplicates(): Address[] {
+    if (this.addressFiles.length <= 1) {
+      return [];
+    }
+
+    const addressToFiles = new Map<Address, Set<string>>();
+
+    for (const labelMap of this.labelToFiles.values()) {
+      for (const [address, files] of labelMap) {
+        if (!addressToFiles.has(address)) {
+          addressToFiles.set(address, new Set());
+        }
+        for (const file of files) {
+          addressToFiles.get(address)!.add(file);
+        }
+      }
+    }
+
+    for (const commentMap of this.commentToFiles.values()) {
+      for (const [address, files] of commentMap) {
+        if (!addressToFiles.has(address)) {
+          addressToFiles.set(address, new Set());
+        }
+        for (const file of files) {
+          addressToFiles.get(address)!.add(file);
+        }
+      }
+    }
+
+    return Array.from(addressToFiles.entries())
+      .filter(([_address, files]) => files.size > 1)
+      .map(([address, _files]) => address);
+  }
+
+  // Check if an address has any labels from files matching the filter substring
+  private hasMatchingFile(address: Address, filesFilter: string): boolean {
+    for (const label of this.combinedParser.labels[address]) {
+      const labelFiles = this.labelToFiles.get(label)?.get(address);
+      if (labelFiles) {
+        for (const file of labelFiles) {
+          if (file.includes(filesFilter)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private displayDuplicateAddress(address: Address): void {
+    console.log(address);
+
+    for (const label of this.combinedParser.labels[address] || []) {
+      this.displayLabelWithFiles(label, address);
+    }
+
+    for (const comment of this.combinedParser.comments[address] || []) {
+      this.displayCommentWithFiles(comment, address);
+    }
+  }
+
+  private displayLabelWithFiles(label: string, address: Address): void {
+    const labelFiles = this.labelToFiles.get(label)?.get(address);
+    if (this.addressFiles.length > 1 && labelFiles && labelFiles.size > 0) {
+      const fileList = Array.from(labelFiles).map(formatPath).join(', ');
+      console.log(`    ${label} (${fileList})`);
+    } else {
+      console.log('    ' + label);
+    }
+  }
+
+  private displayCommentWithFiles(comment: string, address: Address): void {
+    const commentFiles = this.commentToFiles.get(comment)?.get(address);
+    if (this.addressFiles.length > 1 && commentFiles && commentFiles.size > 0) {
+      const fileList = Array.from(commentFiles).map(formatPath).join(', ');
+      console.log(`    // ${comment} (${fileList})`);
+    } else {
+      console.log('    // ' + comment);
+    }
+  }
+}
+
+// Replace home directory with ~ in file paths for cleaner display
+function formatPath(filePath: string): string {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+  if (homeDir && filePath.startsWith(homeDir)) {
+    return filePath.replace(homeDir, '~');
+  }
+  return filePath;
+}
+
+export function listDuplicates(addressFiles: string[], filesFilter?: string): void {
+  const detector = new DuplicatesDetector(addressFiles);
+  detector.displayDuplicates(filesFilter);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,15 +6,19 @@ import * as readline from 'readline';
 
 import { Command } from '@commander-js/extra-typings';
 
-import { Formatter } from './shared/formatter';
-import { RE_ADDRESS_OR_BYTES32 } from './shared/regexps';
-import { Mapper } from './shared/mapper';
-import { Parser } from './shared/parser';
+import { Formatter } from '../shared/formatter';
+import { RE_ADDRESS_OR_BYTES32 } from '../shared/regexps';
+import { Mapper } from '../shared/mapper';
+import { Parser } from '../shared/parser';
+import { fatal } from '../shared/utils';
+
+import { listDuplicates } from './duplicates';
 
 interface CLIOptions {
   duplicates?: boolean;
   format?: string;
   partial?: string;
+  dupFilesFilter?: string;
 }
 
 export function run(): void {
@@ -25,45 +29,32 @@ export function run(): void {
     .version('0.1.0')
     .option('-f, --format <FORMAT>', 'Label format for exact address matches', '%n (0x%4l…%4r)')
     .option('-p, --partial <FORMAT>', 'Label format for partial address matches', '[0x%4l…%n?…%4r]')
-    .option('-d, --duplicates', 'Show duplicates')
-    .argument('<ADDRESS-FILE>', 'path to address book file')
-    .action((addressesFile: string, options: CLIOptions) => {
-      main(addressesFile, options);
+    .option('-d, --duplicates', 'Show duplicates (supports multiple files for cross-file analysis)')
+    .option(
+      '-D, --dup-files-filter <FILTER>',
+      'Only show duplicates with at least one label from a file matching this substring',
+    )
+    .argument('<ADDRESS-FILES...>', 'path(s) to address book file(s)')
+    .action((addressFiles: string[], options: CLIOptions) => {
+      main(addressFiles, options);
     })
     .showHelpAfterError();
 
   program.parse();
 }
 
-function fatal(msg: string): void {
-  console.error(msg + '\n');
-  process.exit(1);
-}
-
-function main(addressesFile: string, options: CLIOptions): void {
-  if (options.duplicates) {
-    listDuplicates(addressesFile);
-  } else {
-    replaceStdin(addressesFile, options);
+function main(addressFiles: string[], options: CLIOptions): void {
+  if (options.dupFilesFilter && !options.duplicates) {
+    fatal('--dup-files-filter can only be used with --duplicates option');
   }
-}
 
-function listDuplicates(addressesFile: string): void {
-  const parser = getParser(addressesFile);
-  let first = true;
-  for (const address of parser.duplicates) {
-    if (first) {
-      first = false;
-    } else {
-      console.log('');
+  if (options.duplicates) {
+    listDuplicates(addressFiles, options.dupFilesFilter);
+  } else {
+    if (addressFiles.length > 1) {
+      fatal('Multiple files only supported with --duplicates option');
     }
-    console.log(address);
-    for (const label of parser.labels[address]) {
-      console.log('    ' + label);
-    }
-    for (const comment of parser.comments[address] || []) {
-      console.log('    // ' + comment);
-    }
+    replaceStdin(addressFiles[0], options);
   }
 }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,0 +1,4 @@
+export function fatal(msg: string): void {
+  console.error(msg);
+  process.exit(1);
+}


### PR DESCRIPTION
- Add support for a new `--dup-files-filter` option to examine
  duplicates by source.
- Try to make CLI invocation more reliable in general.
- Tweaks to guidance for AI agents.